### PR TITLE
TComponent Added caching to fx event processing. (#754)

### DIFF
--- a/framework/TModule.php
+++ b/framework/TModule.php
@@ -16,6 +16,9 @@ namespace Prado;
  * TModule implements the basic methods required by IModule and may be
  * used as the basic class for application modules.
  *
+ * void dyPreInit($config) is raised after loading the module but before
+ * init.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @package Prado
  * @since 3.0

--- a/framework/Util/TCallChain.php
+++ b/framework/Util/TCallChain.php
@@ -137,7 +137,7 @@ class TCallChain extends TList implements IDynamicMethods
 	 * public function dyExampleMethod($param1, $param2, $param3, $callchain)
 	 * $callchain->dyExampleMethod($param1, $param2, $param3)
 	 * }
-	 * {
+	 * }
 	 * </code>
 	 * to call the next event in the chain.
 	 * @param string $method method name of the unspecified object method

--- a/framework/Web/UI/TControl.php
+++ b/framework/Web/UI/TControl.php
@@ -175,6 +175,18 @@ class TControl extends \Prado\TApplicationComponent implements IRenderable, IBin
 	private $_rf = [];
 
 	/**
+	 * TControl need not auto listen to global events because class
+	 * behaviors are not typically added in the middle of running a page
+	 * and the overhead of so many TControls listening and unlistening.
+	 *
+	 * @return bool returns false
+	 */
+	public function getAutoGlobalListen()
+	{
+		return false;
+	}
+
+	/**
 	 * Returns a property value by name or a control by ID.
 	 * This overrides the parent implementation by allowing accessing
 	 * a control via its ID using the following syntax,

--- a/framework/Web/UI/TPage.php
+++ b/framework/Web/UI/TPage.php
@@ -190,6 +190,17 @@ class TPage extends TTemplateControl
 	}
 
 	/**
+	 * TPage does autoGlobalListen and unlisten.  Developers
+	 * may put fx events in the page that need to be picked up.
+	 *
+	 * @return bool returns true
+	 */
+	public function getAutoGlobalListen()
+	{
+		return true;
+	}
+
+	/**
 	 * Runs through the page lifecycles.
 	 * @param \Prado\Web\UI\THtmlWriter $writer the HTML writer
 	 */

--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -951,7 +951,12 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 				continue;
 			}
 			foreach ($list as $param) {
-				if (method_exists($param->getBehavior(), $method)) {
+				$behavior = $param->getBehavior();
+				if (is_array($behavior)) {
+					if (method_exists($behavior['class'], $method)) {
+						return true;
+					}
+				} elseif (method_exists($behavior, $method)) {
 					return true;
 				}
 			}

--- a/tests/unit/TComponentTest.php
+++ b/tests/unit/TComponentTest.php
@@ -799,9 +799,9 @@ class TComponentTest extends PHPUnit\Framework\TestCase
 	public function testGetClassHierarchy()
 	{
 		$component = new DynamicCatchingComponent;
-		$this->assertEquals(['Prado\TComponent', 'NewComponent', 'NewComponentNoListen', 'DynamicCatchingComponent'], $component->getClassHierarchy());
-		$this->assertEquals(['Prado\TComponent', 'NewComponent', 'NewComponentNoListen', 'DynamicCatchingComponent'], $component->getClassHierarchy(false));
-		$this->assertEquals(['prado\tcomponent', 'newcomponent', 'newcomponentnolisten', 'dynamiccatchingcomponent'], $component->getClassHierarchy(true));
+		$this->assertEquals(['DynamicCatchingComponent', 'NewComponentNoListen', 'NewComponent', 'Prado\TComponent'], $component->getClassHierarchy());
+		$this->assertEquals(['DynamicCatchingComponent', 'NewComponentNoListen', 'NewComponent', 'Prado\TComponent'], $component->getClassHierarchy(false));
+		$this->assertEquals(['dynamiccatchingcomponent', 'newcomponentnolisten', 'newcomponent', 'prado\tcomponent'], $component->getClassHierarchy(true));
 	}
 
 


### PR DESCRIPTION
* TComponent caches class fx methods

* TComponent corrrected PHPDoc for fx method getter

* TComponent added @return to phpdoc for getclassfxevents

* TComponent::filter_prado_fx replaced strncasecmp with a faster custom solution

This new code is 38% faster than the old in php 7.4, according to my tests.

10,000,000 calls to scrncasecmp took 1.37443 seconds
10,000,000 the custom check took 0.85108 seconds

The check alternated between 'dyEvent' and 'fxevent' as input

* Corrected the variable in TComponent::getClassFxEvents

don't know how i missed that.

* reverting.  bad test data.  strncasecmp still faster

* TComponent speed bump when raising a dynamic event that doesn't exist

* TTemplate looking at class behaviors with the new style of pre-instanced behavior definitions

* TCallChain phpdoc correction

* TControl AutoGlobalListen turned off

By the time TControl are constructed, class behaviors should all be in place, removing the need to auto listen.  New class behaviors are likely not to be added during a page run, only before.

* TPage may have user defined fx events that need to be picked up

* TPage removed additional spacing for php cs fixer

* TComponent::__construct pop off the TComponent as those cannot have attached class behaviors

* TComponent::getClassHierarchy caching

How fast are the PHP calls on classes and for parent classes?

* TComponent::getClassHirerarchy reversed ordering, fixed TComponentTest unit test

* TComponent phpdoc spelling correction

* TComponent::getClassHierarchy Keep any stored caches